### PR TITLE
FIX: Non-ARCHIVAL_RCD_TYPE events have 'reserved' and 'timestamp' fields

### DIFF
--- a/estreamer/eventdata.py
+++ b/estreamer/eventdata.py
@@ -629,6 +629,8 @@ class EventData(Struct):
                 self._field_format_.update({'timestamp': 'I', 'reserved': 'I'})
                 super(EventData, self).__init__(*args, **kwargs)
             else:
+                # The field values do not reset after being extended for some reason (metaclass). Without this, all events parsed after the first ARCHIVAL_RCD gets parsed as if it has the 'reserved' and 'timestamp field'
+                self._fields_ = [field_ for field_ in self._fields_ if field_[0] not in ['timestamp', 'reserved']]
                 super(EventData, self).__init__(*args, **kwargs)
             self._unpack_data()
 


### PR DESCRIPTION
It seems that all EventData records parsed after the first ARCHIVAL_RCD_TYPE have 'reserved' and 'timestamp' fields, even though they should not, and thus don't get parsed properly.

I'm not sure if there's a better way to do this.